### PR TITLE
FSLOta: allow FSLOta to read external storage data

### DIFF
--- a/FSLOta/AndroidManifest.xml
+++ b/FSLOta/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REBOOT" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application


### PR DESCRIPTION
Must be defined for reading /system/etc/ota.conf file which contains
OTA server DNS name and server port.