### PR TITLE
FSLOta: pass OTA server IP, port & URL to build props

### DIFF
--- a/FSLOta/res/values/strings.xml
+++ b/FSLOta/res/values/strings.xml
@@ -17,4 +17,7 @@
         <string name="length_unknown">Unknown</string>
         <string name="verify_package">Verifying package</string>
         <string name="full_version">Description</string>
+        <string name="ota_server_ip">lighthouse.net</string>
+        <string name="ota_server_port">8080</string>
+        <string name="ota_server_url">/api/v1/rom</string>
     </resources>

--- a/FSLOta/src/com/fsl/android/ota/BuildPropParser.java
+++ b/FSLOta/src/com/fsl/android/ota/BuildPropParser.java
@@ -70,6 +70,10 @@ public class BuildPropParser {
 
     private void setFile(File file) throws IOException {
         try {
+            propHM.put("server", mContext.getString(R.string.ota_server_ip));
+            propHM.put("port", mContext.getString(R.string.ota_server_port));
+            propHM.put("server_url", mContext.getString(R.string.ota_server_url));
+
             FileReader reader = new FileReader(file);
             BufferedReader in = new BufferedReader(reader);
             String string;


### PR DESCRIPTION
Read server IP, port & URL from strings.xml and save it to BuildPropParser
as readed build props (some kind of faked build prop).