### PR TITLE
FSLOta: handle exception when no OTA server IP, port or URL

### DIFF
--- a/FSLOta/src/com/fsl/android/ota/BuildPropParser.java
+++ b/FSLOta/src/com/fsl/android/ota/BuildPropParser.java
@@ -87,7 +87,7 @@ public class BuildPropParser {
                 }
             }
             in.close();
-        } catch (IOException e) {
+        } catch (Exception e) {
             e.printStackTrace();
             throw e;
         }


### PR DESCRIPTION
Handle exception when we have no OTA server IP, port or URL in string.xml.