### PR TITLE
Ethernet: reset interface at startup

### DIFF
--- a/Ethernet/AndroidManifest.xml
+++ b/Ethernet/AndroidManifest.xml
@@ -9,6 +9,8 @@
         android:minSdkVersion="19"
         android:targetSdkVersion="19" />
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
@@ -25,6 +27,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <receiver
+            android:name=".EthernetBootReceiver"
+            android:enabled="true"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/Ethernet/com/fsl/ethernet/EthernetBootReceiver.java
+++ b/Ethernet/com/fsl/ethernet/EthernetBootReceiver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 Boundary Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fsl.ethernet;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+import com.fsl.ethernet.EthernetManager;
+
+public class EthernetBootReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "EthernetBootReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.d(TAG, "onReceive " + intent.getAction());
+        if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+            Log.d(TAG, "resetting interface");
+            EthernetManager ethManager = new EthernetManager(context);
+            ethManager.resetInterface();
+        }
+    }
+}


### PR DESCRIPTION
Via adding BOOT_COMPLETED receiver.
Otherwise the interface reset to saved settings (static IP for instace)
only happen when the application is started manually.