### PR TITLE
Ethernet: do not use deprecated getNetworkInfo()

### DIFF
--- a/Ethernet/com/fsl/ethernet/EthernetManager.java
+++ b/Ethernet/com/fsl/ethernet/EthernetManager.java
@@ -501,6 +501,9 @@ public class EthernetManager {
 	}
     }
     public boolean isEthernetConnect(){
-        return mConnMgr.getNetworkInfo(ConnectivityManager.TYPE_ETHERNET).isConnected();
+        if(mConnMgr.getActiveNetworkInfo() != null) {
+            return mConnMgr.getActiveNetworkInfo().getType() == ConnectivityManager.TYPE_ETHERNET;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Fix bug when user unable to change network settings: even when ethernet cable in inserted,
user gets messages like "unable to change network settings, connect ethernet cable first".

As getNetworkInfo() does not work properly with ethernet, switched to getActiveNetworkInfo().